### PR TITLE
Admin Can Set Round Numbers [#41] (https://github.com/witseie-elen4010/2024-group-lab-003/issues/41)

### DIFF
--- a/src/controllers/roomController.js
+++ b/src/controllers/roomController.js
@@ -278,6 +278,30 @@ async function userIsInRoom (req, res) {
   }
 }
 
+// Create a function to set the number of rounds for a room
+async function setNumRounds (req, res) {
+  const { roomID, numRounds } = req.params // Extract the room ID and number of rounds from request parameters
+
+  try {
+    // Update the room to set the number of rounds
+    const updatedRoom = await Room.findByIdAndUpdate(roomID, { $set: { numRounds } })
+
+    if (!updatedRoom) {
+      return res.status(404).json({ success: false, message: 'Room not found' })
+    }
+
+    // Respond with the updated room
+    res.json({
+      success: true,
+      message: 'Number of rounds updated successfully',
+      room: updatedRoom
+    })
+  } catch (error) {
+    console.error('Error updating number of rounds:', error)
+    res.status(500).json({ success: false, message: 'Internal server error' })
+  }
+}
+
 module.exports = {
   getRoomPlayers,
   joinRoom,
@@ -288,5 +312,6 @@ module.exports = {
   checkRoomStarted,
   removePlayerFromRoomByID,
   removePlayerFromRoomByNickname,
-  userIsInRoom
+  userIsInRoom,
+  setNumRounds
 }

--- a/src/routes/dbRoutes.js
+++ b/src/routes/dbRoutes.js
@@ -11,6 +11,7 @@ const { checkRoomStarted } = require('../controllers/roomController')
 const { removePlayerFromRoomByID } = require('../controllers/roomController')
 const { removePlayerFromRoomByNickname } = require('../controllers/roomController')
 const { userIsInRoom } = require('../controllers/roomController')
+const { setNumRounds } = require('../controllers/roomController')
 
 router.post('/create-room', createRoom)
 router.post('/join-room', joinRoom)
@@ -22,5 +23,6 @@ router.get('/check-room-started/:roomId', checkRoomStarted)
 router.post('/remove-player-from-room-by-user-id/:userID/:roomID', removePlayerFromRoomByID)
 router.post('/remove-player-from-room-by-user-nickname/:userNickname/:roomID', removePlayerFromRoomByNickname)
 router.get('/user-is-in-room/:roomID/:userID', userIsInRoom)
+router.post('/set-num-rounds/:roomID/:numRounds', setNumRounds)
 
 module.exports = router

--- a/src/services/dbSchema.js
+++ b/src/services/dbSchema.js
@@ -8,7 +8,8 @@ const userSchema = new mongoose.Schema({
 const roomSchema = new mongoose.Schema({
   code: { type: String, required: true, unique: true },
   createTime: { type: Date, default: Date.now },
-  hasStarted: { type: Boolean, default: false } // Default value set to false
+  hasStarted: { type: Boolean, default: false },
+  numRounds: { type: Number, required: false }
 })
 
 const roomPlayerSchema = new mongoose.Schema({


### PR DESCRIPTION
closes #41 

# Admin Can Set Round Numbers

## Description
In the waiting room, the admin can view game settings. The admin can see the number of rounds in the upcoming game, however the number of rounds always needs to be greater than the number of players in the waiting room. 

## Acceptance criteria
- The admin can view the game settings 
- The admin can change the number of roudns
- A user cannot see the game settings
- If an admin enters a number of rounds smaller than the number of players in the waiting room. It is automatically changed to be equal to the number of players in the waiting room
- The database is updated such that the current room's number of rounds, is what the admin entered

## Story Points

- 2  story points 